### PR TITLE
Adds filterable viewer

### DIFF
--- a/NlogViewer/LogEventViewModel.cs
+++ b/NlogViewer/LogEventViewModel.cs
@@ -43,7 +43,7 @@ namespace NlogViewer
                 Background = Brushes.Yellow;
                 BackgroundMouseOver = Brushes.GreenYellow;
             }
-            else if (logEventInfo.Level == LogLevel.Error)
+            else if (logEventInfo.Level == LogLevel.Error || logEventInfo.Level == LogLevel.Fatal)
             {
                 Background = Brushes.Tomato;
                 BackgroundMouseOver = Brushes.IndianRed;

--- a/NlogViewer/NLogViewerFilterable.xaml
+++ b/NlogViewer/NLogViewerFilterable.xaml
@@ -1,0 +1,102 @@
+﻿<UserControl x:Class="NlogViewer.NLogViewerFilterable"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:nlogViewer="clr-namespace:NlogViewer"
+             mc:Ignorable="d" 
+             DataContext="{Binding RelativeSource={RelativeSource Self}}"
+             d:DesignHeight="230" d:DesignWidth="500">
+    <UserControl.Resources>
+        <Style TargetType="CheckBox" x:Key="checkboxStyle">
+            <Setter Property="FontSize" Value="15"/>
+            <Setter Property="Margin" Value="10,-2,10,10"/>
+        </Style>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="140px"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid Grid.Column="0" Background="#f2f3f4">
+            <StackPanel Margin="10" MaxHeight="200" VerticalAlignment="Top" Background="#c1c7c9">
+                <TextBlock Text="Choose levels" FontSize="17" Margin="0,0,0,20"/>
+
+                <CheckBox Style="{StaticResource checkboxStyle}" IsChecked="{Binding ShowInfo}">
+                    <CheckBox.Content>
+                        <TextBlock Text="Info" Margin="0,-2,0,0"/>
+                    </CheckBox.Content>
+                </CheckBox>
+                <CheckBox Style="{StaticResource checkboxStyle}" IsChecked="{Binding ShowTrace}">
+                    <CheckBox.Content>
+                        <TextBlock Text="Trace" Margin="0,-2,0,0"/>
+                    </CheckBox.Content>
+                </CheckBox>
+                <CheckBox Style="{StaticResource checkboxStyle}" IsChecked="{Binding ShowWarn}">
+                    <CheckBox.Content>
+                        <TextBlock Text="Warn" Margin="0,-2,0,0"/>
+                    </CheckBox.Content>
+                </CheckBox>
+                <CheckBox Style="{StaticResource checkboxStyle}" IsChecked="{Binding ShowDebug}">
+                    <CheckBox.Content>
+                        <TextBlock Text="Debug" Margin="0,-2,0,0"/>
+                    </CheckBox.Content>
+                </CheckBox>
+                <CheckBox Style="{StaticResource checkboxStyle}" IsChecked="{Binding ShowError}">
+                    <CheckBox.Content>
+                        <TextBlock Text="Error" Margin="0,-2,0,0"/>
+                    </CheckBox.Content>
+                </CheckBox>
+                <CheckBox Style="{StaticResource checkboxStyle}" IsChecked="{Binding ShowFatal}">
+                    <CheckBox.Content>
+                        <TextBlock Text="Fatal" Margin="0,-2,0,0"/>
+                    </CheckBox.Content>
+                </CheckBox>
+            </StackPanel>
+        </Grid>
+        <Grid Grid.Column="1">
+            <DataGrid AutoGenerateColumns="False" ItemsSource="{Binding LogEntries}" Name="grid" 
+                      CanUserAddRows="False" CanUserDeleteRows="False" CanUserReorderColumns="True" IsReadOnly="True">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Time"
+                                        Binding="{Binding Time}" 
+                                        Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NLogViewerFilterable}}, Path=TimeWidth}">
+                    </DataGridTextColumn>
+
+                    <DataGridTextColumn Header="Logger"
+                                        Binding="{Binding LoggerName}"  
+                                        Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NLogViewerFilterable}}, Path=LoggerNameWidth}" />
+
+                    <DataGridTextColumn Header="Level" 
+                                        Binding="{Binding Level}" 
+                                        Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NLogViewerFilterable}}, Path=LevelWidth}" />
+                    
+                    <DataGridTextColumn Header="Message" 
+                                        Binding="{Binding FormattedMessage}" 
+                                        Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NLogViewerFilterable}}, Path=MessageWidth}"/>
+
+                    <DataGridTextColumn Header="Exception"
+                                        Binding="{Binding Exception}"  
+                                        Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NLogViewerFilterable}}, Path=ExceptionWidth}"/>
+                </DataGrid.Columns>
+                <DataGrid.ItemContainerStyle>
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="ToolTip" Value="{Binding ToolTip}"/>
+                        <Setter Property="Background" Value="{Binding Background}" />
+                        <Setter Property="Foreground" Value="{Binding Foreground}" />
+                        <Style.Triggers>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter Property="Background" Value="DarkOrange"/>
+                                <Setter Property="Foreground" Value="black"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Background" Value="{Binding BackgroundMouseOver}"/>
+                                <Setter Property="Foreground" Value="{Binding ForegroundMouseOver}"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </DataGrid.ItemContainerStyle>
+            </DataGrid>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/NlogViewer/NLogViewerFilterable.xaml.cs
+++ b/NlogViewer/NLogViewerFilterable.xaml.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace NlogViewer
+{
+    /// <summary>
+    /// Interaction logic for NLogViewerFilterable.xaml
+    /// </summary>
+    public partial class NLogViewerFilterable : UserControl, INotifyPropertyChanged
+    {
+        public ObservableCollection<LogEventViewModel> LogEntries { get; private set; }
+
+        public bool IsTargetConfigured { get; private set; }
+
+        [Description("Width of time column in pixels"), Category("Data")]
+        [TypeConverterAttribute(typeof(LengthConverter))]
+        public double TimeWidth { get; set; }
+
+        [Description("Width of Logger column in pixels, or auto if not specified"), Category("Data")]
+        [TypeConverterAttribute(typeof(LengthConverter))]
+        public double LoggerNameWidth { set; get; }
+
+        [Description("Width of Level column in pixels"), Category("Data")]
+        [TypeConverterAttribute(typeof(LengthConverter))]
+        public double LevelWidth { get; set; }
+        
+        [Description("Width of Message column in pixels"), Category("Data")]
+        [TypeConverterAttribute(typeof(LengthConverter))]
+        public double MessageWidth { get; set; }
+        
+        [Description("Width of Exception column in pixels"), Category("Data")]
+        [TypeConverterAttribute(typeof(LengthConverter))]
+        public double ExceptionWidth { get; set; }
+
+        [Description("Maximum number of log entries to show"), Category("Data")]
+        public int MaximumLogEntries { get; set; }
+
+        #region "Flags to turn show/hide levels"
+        bool showTrace = true, showInfo = true, showDebug = true, showWarn = true, showError = true, showFatal = true;
+        
+        public bool ShowTrace 
+        {
+            get { return showTrace; }
+            set { showTrace = value; OnPropertyChanged("ShowTrace"); }
+        }
+
+        public bool ShowInfo
+        {
+            get { return showInfo; }
+            set { showInfo = value; OnPropertyChanged("ShowInfo"); }
+        }
+
+        public bool ShowDebug
+        {
+            get { return showDebug; }
+            set { showDebug = value; OnPropertyChanged("ShowDebug"); }
+        }
+
+        public bool ShowWarn
+        {
+            get { return showWarn; }
+            set { showWarn = value; OnPropertyChanged("ShowWarn"); }
+        }
+
+        public bool ShowError
+        {
+            get { return showError; }
+            set { showError = value; OnPropertyChanged("ShowError"); }
+        }
+
+        public bool ShowFatal
+        {
+            get { return showFatal; }
+            set { showFatal = value; OnPropertyChanged("ShowFatal"); }
+        }
+
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            if (PropertyChanged != null) PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #endregion
+
+        public NLogViewerFilterable()
+        {
+            IsTargetConfigured = false;
+            LogEntries = new ObservableCollection<LogEventViewModel>();
+
+            InitializeComponent();
+
+            if (!DesignerProperties.GetIsInDesignMode(this))
+            {
+                foreach (NlogViewerTarget target in NLog.LogManager.Configuration.AllTargets.Where(t => t is NlogViewerTarget).Cast<NlogViewerTarget>())
+                {
+                    IsTargetConfigured = true;
+                    target.LogReceived += LogReceived;
+                }
+            }
+        }
+
+        protected void LogReceived(NLog.Common.AsyncLogEventInfo log)
+        {
+            LogEventViewModel vm = new LogEventViewModel(log.LogEvent);
+
+            Dispatcher.BeginInvoke(new Action(() =>
+            {
+                bool addLogEvent = false;
+                switch(vm.Level.ToLower())
+                {
+                    case "debug": addLogEvent = ShowDebug; break;
+                    case "info": addLogEvent = ShowInfo; break;
+                    case "trace": addLogEvent = ShowTrace; break;
+                    case "warn": addLogEvent = ShowWarn; break;
+                    case "error": addLogEvent = ShowError; break;
+                    case "fatal": addLogEvent = ShowFatal; break;
+                }
+                if (!addLogEvent) return;
+                if (LogEntries.Count >= MaximumLogEntries) LogEntries.RemoveAt(0);
+
+                LogEntries.Add(vm);
+                grid.ScrollIntoView(vm);
+            }));
+        }
+    }
+}

--- a/NlogViewer/NlogViewer.csproj
+++ b/NlogViewer/NlogViewer.csproj
@@ -35,8 +35,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NLog">
+    <Reference Include="NLog, Version=3.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.3.0.0.0\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -54,8 +55,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LogEventViewModel.cs" />
-    <Compile Include="NlogViewer.xaml.cs">
-      <DependentUpon>NlogViewer.xaml</DependentUpon>
+    <Compile Include="NLogViewerFilterable.xaml.cs">
+      <DependentUpon>NLogViewerFilterable.xaml</DependentUpon>
     </Compile>
     <Compile Include="NlogViewerTarget.cs" />
   </ItemGroup>
@@ -90,7 +91,7 @@
     <AppDesigner Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <Page Include="NlogViewer.xaml">
+    <Page Include="NLogViewerFilterable.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -103,6 +104,13 @@ NuGet.exe pack "$(ProjectDir)NlogViewer.csproj" -Prop Configuration=Release
 
 )</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Sample/MainWindow.xaml
+++ b/Sample/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:nlog ="clr-namespace:NlogViewer;assembly=NlogViewer"
-        Title="NLogWPFControl Sample" Height="350" Width="525">
+        Title="NLogWPFControl Sample" Height="400" Width="550">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="auto"></RowDefinition>
@@ -32,7 +32,8 @@
 
 
         <GroupBox Grid.Row="2" Header="NlogViewer">
-            <nlog:NlogViewer x:Name="logCtrl" TimeWidth="AUTO" LoggerNameWidth="0" LevelWidth="auto" ExceptionWidth="auto" MessageWidth="auto" /> 
+            <!--<nlog:NlogViewer x:Name="logCtrl" TimeWidth="AUTO" LoggerNameWidth="0" LevelWidth="auto" ExceptionWidth="auto" MessageWidth="auto" />-->
+            <nlog:NLogViewerFilterable TimeWidth="AUTO" LoggerNameWidth="100" LevelWidth="auto" ExceptionWidth="200" MessageWidth="auto" MaximumLogEntries="100"/>
         </GroupBox>
 
     </Grid>

--- a/Sample/MainWindow.xaml
+++ b/Sample/MainWindow.xaml
@@ -19,6 +19,7 @@
                     <Button x:Name="btnDebug" Content="Debug" Click="Send_Click" />
                     <Button x:Name="btnWarning" Content="Warning" Click="Send_Click" />
                     <Button x:Name="btnError" Content="Error" Click="Send_Click" />
+                    <Button x:Name="btnFatal" Content="Fatal" Click="Send_Click"/>
                 </StackPanel>
             </StackPanel>            
         </GroupBox>

--- a/Sample/MainWindow.xaml.cs
+++ b/Sample/MainWindow.xaml.cs
@@ -39,7 +39,7 @@ namespace Sample
             if (sender.Equals(btnDebug)) level = LogLevel.Debug;
             if (sender.Equals(btnWarning)) level = LogLevel.Warn;
             if (sender.Equals(btnError)) level = LogLevel.Error;
-
+            if (sender.Equals(btnFatal)) level = LogLevel.Fatal;
             log.Log(level, tbLogText.Text);
         }
 


### PR DESCRIPTION
Added a usercontrol which uses the same datacontext properties, but the XAML is different on 2 counts:

1. Has a collection of checkboxes which allow the user to toggle logging levels
2. Uses DataGrid instead of ListView. We can implement filtering within the grid later on. A usecase would be to lookout for events based on a keyword in the FormattedMessage field.

So current filtering is applied on the log level.

Updated Sample to use the new usercontrol.