### PR TITLE
Show Exceptions in greater detail

### DIFF
--- a/NlogViewer/NlogViewer.xaml
+++ b/NlogViewer/NlogViewer.xaml
@@ -1,16 +1,15 @@
-﻿<UserControl x:Class="NlogViewer.NlogViewer"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:nlogViewer="clr-namespace:NlogViewer"
-             mc:Ignorable="d"
-             d:DesignHeight="230" d:DesignWidth="457"
-             DataContext="{Binding RelativeSource={RelativeSource Self}}">
-    <UserControl.Resources>
-    </UserControl.Resources>
+<UserControl 
+    x:Class="NlogViewer.NlogViewer"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:nlogViewer="clr-namespace:NlogViewer"
+    mc:Ignorable="d"
+    d:DesignHeight="230" d:DesignWidth="457"
+    DataContext="{Binding RelativeSource={RelativeSource Self}}">
     <Grid>
-        <ListView ItemsSource="{Binding LogEntries}" Name="logView">
+        <ListView ScrollViewer.HorizontalScrollBarVisibility="Disabled" ItemsSource="{Binding LogEntries}" Name="logView">
             <ListView.ItemContainerStyle>
                 <Style TargetType="{x:Type ListViewItem}">
                     <EventSetter Event="PreviewMouseLeftButtonDown" Handler="LoggerOnClick" />
@@ -30,9 +29,9 @@
                 </Style>
             </ListView.ItemContainerStyle>
             <ListView.View>
-                <GridView>
+                <GridView ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                     <GridView.Columns>
-                        <GridViewColumn DisplayMemberBinding="{Binding Time}" Header="Time" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=TimeWidth}"/>
+                        <GridViewColumn x:Name="timeCol" DisplayMemberBinding="{Binding Time}" Header="Time" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=TimeWidth}"/>
                         <GridViewColumn DisplayMemberBinding="{Binding LoggerName}" Header="Logger" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=LoggerNameWidth}"/>
                         <GridViewColumn DisplayMemberBinding="{Binding Level}" Header="Level" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=LevelWidth}"/>
                         <GridViewColumn Header="Message" Width="{Binding ElementName=helperField, Path=ActualWidth}">
@@ -46,8 +45,8 @@
                 </GridView>
             </ListView.View>
         </ListView>
-      
-        <!-- Hidden Grid which does resizing of the ListView to allow the message column to fill remaining space -->
+
+        <!-- Hidden Grid which does resizing of the ListView to allow the Message Column to fill remaining space -->
         <Grid x:Name="HiddenHelper" Visibility="Hidden">
             <Grid.ColumnDefinitions>
                 <!-- Width is bound to width of the first GridViewColumn -->
@@ -57,6 +56,7 @@
                 <!-- Correction Width -->
                 <ColumnDefinition Width="10"/>
             </Grid.ColumnDefinitions>
+            <!-- This is the hidden helper Field which is used to bind to, using the "Fill" column of the helper grid -->
             <Grid Grid.Column="1" x:Name="helperField"/>
         </Grid>
 

--- a/NlogViewer/NlogViewer.xaml
+++ b/NlogViewer/NlogViewer.xaml
@@ -34,11 +34,42 @@
                         <GridViewColumn DisplayMemberBinding="{Binding Time}" Header="Time" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=TimeWidth}"/>
                         <GridViewColumn DisplayMemberBinding="{Binding LoggerName}" Header="Logger" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=LoggerNameWidth}"/>
                         <GridViewColumn DisplayMemberBinding="{Binding Level}" Header="Level" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=LevelWidth}"/>
-                        <GridViewColumn DisplayMemberBinding="{Binding FormattedMessage}"  Header="Message" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=MessageWidth}"/>
-                        <GridViewColumn DisplayMemberBinding="{Binding Exception}" Header="Exception" Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type nlogViewer:NlogViewer}}, Path=ExceptionWidth}"/>
+                        <GridViewColumn Header="Message" Width="{Binding ElementName=helperField, Path=ActualWidth}">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <TextBlock TextWrapping="Wrap" Text="{Binding FormattedMessage}"/>
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
                     </GridView.Columns>
                 </GridView>
             </ListView.View>
         </ListView>
+      
+        <!-- Hidden Grid which does resizing of the ListView to allow the message column to fill remaining space -->
+        <Grid x:Name="HiddenHelper" Visibility="Hidden">
+            <Grid.ColumnDefinitions>
+                <!-- Width is bound to width of the first GridViewColumn -->
+                <ColumnDefinition Width="{Binding ElementName=timeCol, Path=ActualWidth}"/>
+                <!-- Width is set to "Fill" -->
+                <ColumnDefinition Width="*"/>
+                <!-- Correction Width -->
+                <ColumnDefinition Width="10"/>
+            </Grid.ColumnDefinitions>
+            <Grid Grid.Column="1" x:Name="helperField"/>
+        </Grid>
+
+        <!-- Display an Exception in greater detail when clicked on -->
+        <Popup Name="Popup"
+            Placement="Bottom"
+            VerticalOffset="-172"
+            HorizontalOffset="-10"
+            AllowsTransparency="True"
+            StaysOpen="False">
+            <Grid MinHeight="183" Width="{Binding ElementName=HiddenHelper, Path=ActualWidth}">
+                <TextBox IsReadOnly="True" x:Name="PopupText" Margin="10" TextWrapping="Wrap" Padding="7"/>
+                <Button x:Name="CloseButton" FontSize="10" VerticalAlignment="Top" HorizontalAlignment="Right" Background="Red" Foreground="White" Width="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=ActualHeight}"  HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Click="Hide" Content="X"/>
+            </Grid>
+        </Popup>
     </Grid>
 </UserControl>

--- a/NlogViewer/NlogViewer.xaml
+++ b/NlogViewer/NlogViewer.xaml
@@ -13,6 +13,7 @@
         <ListView ItemsSource="{Binding LogEntries}" Name="logView">
             <ListView.ItemContainerStyle>
                 <Style TargetType="{x:Type ListViewItem}">
+                    <EventSetter Event="PreviewMouseLeftButtonDown" Handler="LoggerOnClick" />
                     <Setter Property="ToolTip" Value="{Binding ToolTip}" />
                     <Setter Property="Background" Value="{Binding Background}" />
                     <Setter Property="Foreground" Value="{Binding Foreground}" />

--- a/NlogViewer/NlogViewer.xaml.cs
+++ b/NlogViewer/NlogViewer.xaml.cs
@@ -6,6 +6,8 @@ using System.Windows;
 using System.Windows.Controls;
 using NLog;
 using NLog.Common;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
 
 namespace NlogViewer
 {
@@ -133,6 +135,42 @@ namespace NlogViewer
         private void ScrollToItem(object item)
         {
             LogView.ScrollIntoView(item);
+        }
+
+        /// <summary>
+        /// Display the Exception popup when a log is clicked on.
+        /// </summary>
+        /// <param name="sender">Clicked on ListViewItem</param>
+        /// <param name="e">Mouse Click Event</param>
+        private void LoggerOnClick(object sender, MouseButtonEventArgs e)
+        {
+            if(sender != null)
+            {
+                var layer = sender as ListViewItem;
+                if (layer != null)
+                {
+                    var content = layer.Content as LogEventViewModel;
+                    if (content != null)
+                    {
+                        var exception = content.Exception;
+                        if (exception != null)
+                        {
+                            PopupText.Text = exception.ToString();
+                            Popup.IsOpen = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Close the Exception popup.
+        /// </summary>
+        /// <param name="sender">Close button</param>
+        /// <param name="e">Routed Event</param>
+        private void Hide(object sender, RoutedEventArgs e)
+        {
+            Popup.IsOpen = false;
         }
 
     }

--- a/NlogViewer/NlogViewer.xaml.cs
+++ b/NlogViewer/NlogViewer.xaml.cs
@@ -144,7 +144,7 @@ namespace NlogViewer
         /// <param name="e">Mouse Click Event</param>
         private void LoggerOnClick(object sender, MouseButtonEventArgs e)
         {
-            if(sender != null)
+            if (sender != null)
             {
                 var layer = sender as ListViewItem;
                 if (layer != null)


### PR DESCRIPTION
Thanks for the great NLogViewer, has helped me a ton. My main problem was that I wanted the ability to view Exceptions in full detail which I have done in a simple way using a popup. When an Exception / Error is logged with the exception passed with the message, for example:

```csharp
catch (MyException ex) 
{ 
    logger.Error(ex, "Got exception.");
}
```

the NLogViewer will look the same, but the logged ListViewItem can be clicked on like so to open a popup and display the full exception:

![exceptionpopup](https://user-images.githubusercontent.com/37150799/67294327-aff67a00-f4b3-11e9-8637-9dbad7975a4e.png)

The popup is closed using the red X or by clicking off of it. This helps debugging by displaying long and detailed errors in full.

My code also has one minor change that has the Message column wrap text so longer messages will not have to make the user scroll horizontally forever. This also allowed the Message column to fill the length of the screen when the screen is resized and gives the popup the same width as the NLogViewer. This change was to remove any unnecessary scrolling and to have the NLogViewer fit whatever width it was put into.

![longmessagelogged](https://user-images.githubusercontent.com/37150799/67297413-dfa78100-f4b7-11e9-8e98-f4e635c2bdb1.PNG)

My examples have the LoggerName and Level columns removed but that was only because my program does not need to display them, these changes will still work with those columns in use.